### PR TITLE
Move modal declaration above its usage in generateText

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import loadComponents from './components';
 import loadBlocks from './blocks';
 import axios from 'axios';
 
-
+// Get the Modal module from the editor
+const modal = editor.Modal;
 
 export default (editor, opts = {}) => {
   window.generateText = async () => { 
@@ -111,8 +112,6 @@ export default (editor, opts = {}) => {
     }
   }
 
-  // Get the Modal module from the editor
-  const modal = editor.Modal;
   const modelContent = `
   
 <!-- Add this HTML inside your GrapesJS editor page -->
@@ -158,13 +157,10 @@ export default (editor, opts = {}) => {
 </div>
 `
 
-
   const openModal = () => {
     modal.setContent(modelContent);
     modal.open();
   }
-
-
 
   var wordCount = 0;
   var contextCount = 0;
@@ -181,9 +177,6 @@ export default (editor, opts = {}) => {
   loadComponents(editor, options);
   // Add blocks
   loadBlocks(editor, options);
-
-
-
 
   // This function will open the prompt creation UI
   function openPromptCreationUI() {


### PR DESCRIPTION
Fixes #2

Move the `modal` declaration above its usage in `generateText` in `src/index.js`.

* Declare `modal` at the top of the file, before the `generateText` function.
* Remove the previous `modal` declaration after the `generateText` function.
* Adjust the `generateText` function to use the `modal` variable after it has been declared.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rileyseaburg/grapesjs-openai/pull/3?shareId=921e07da-8a70-4fd2-8ac0-2d39dfe2579b).